### PR TITLE
Add new GitHub workflow for running Go tests

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,21 @@
+---
+# GitHub workflow to run go test inside nested Podman container
+on:
+  pull_request:
+  workflow_dispatch:
+jobs:
+  go_test:
+    name: Run go test
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Dependencies
+        shell: bash
+        run: task container-go-test

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -1,5 +1,6 @@
+---
 # https://taskfile.dev/
-version: '3'
+version: "3"
 
 tasks:
   default:
@@ -16,6 +17,10 @@ tasks:
 
   list:
     desc: List available tasks
-    internal: true
     cmds:
       - task --list
+
+  container-go-test:
+    desc: Run Go tests inside Podman container
+    cmds:
+      - echo Run go test


### PR DESCRIPTION
This patch is preparation for a future patch adding the real container-go-test task target.